### PR TITLE
fix: [PI-193] do not normalize hagall endpoint

### DIFF
--- a/hdsclient/client_opts.go
+++ b/hdsclient/client_opts.go
@@ -11,7 +11,7 @@ type ClientOpts func(*Client)
 
 func WithHagallEndpoint(v string) ClientOpts {
 	return func(c *Client) {
-		c.HagallEndpoint = httpcmn.NormalizeEndpoint(v)
+		c.HagallEndpoint = v
 	}
 }
 


### PR DESCRIPTION
Hagall is normalizing its public endpoint sometimes, not always
during the pairing, it is supposed to use whatever set in the configuration
but in hagall-common/hdsclient, it fills in a normalized endpoint if input endpoint is empty, I doubt why empty endpoint should be allowed.
https://github.com/aukilabs/hagall-common/blob/3bec816bc1c0efa403e51b3c54ae3d09228313a3/hdsclient/client.go#L194

when it comes to healthcheck, it strips the trailing slash, and put it in a JWT
https://github.com/aukilabs/hagall-common/blob/3bec816bc1c0efa403e51b3c54ae3d09228313a3/hdsclient/client_opts.go#L14
https://github.com/aukilabs/hagall-common/blob/3bec816bc1c0efa403e51b3c54ae3d09228313a3/hdsclient/client.go#L272
HDS parses hagall's endpoint from the JWT, looks up the server
https://github.com/aukilabs/hail/blob/a724735567b592a8c561aa056bb732415accc01c/hds/http/identity.go#L45
https://github.com/aukilabs/hail/blob/a724735567b592a8c561aa056bb732415accc01c/hds/http/identity.go#L25
https://github.com/aukilabs/hail/blob/a724735567b592a8c561aa056bb732415accc01c/hds/http/identity.go#L72