### PR TITLE
fix: retract broken version v0.1.9

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,10 @@ module github.com/aukilabs/hagall-common
 
 go 1.21
 
+retract (
+    v0.1.9 // Wrong publish
+)
+
 require (
 	github.com/aukilabs/go-tooling v0.14.5
 	github.com/ethereum/go-ethereum v1.13.14


### PR DESCRIPTION
The tag was on a feature branch, doesn't contain some changes from main branch. It breaks Hagall
<img width="361" alt="Screenshot 2024-04-10 at 15 54 43" src="https://github.com/aukilabs/hagall-common/assets/137246803/13b51dbd-ddec-4887-a99b-065e481b32c8">
