### PR TITLE
fix: only update time and sign identity if the caller is HDS

### DIFF
--- a/hdsclient/client.go
+++ b/hdsclient/client.go
@@ -275,17 +275,22 @@ func (c *Client) HandleHealthCheck(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	token, err := httpcmn.SignIdentity(c.HagallEndpoint, c.Secret())
-	if err != nil {
-		httpcmn.InternalServerError(w, errors.New("signing response failed").Wrap(err))
-		return
+	userAgent := r.Header.Get("User-Agent")
+	if strings.HasPrefix(userAgent, "HDS v") {
+		token, err := httpcmn.SignIdentity(c.HagallEndpoint, c.Secret())
+		if err != nil {
+			nonSensitiveErr := errors.New("failed to sign identity")
+			logs.Error(nonSensitiveErr.Wrap(err))
+			httpcmn.InternalServerError(w, nonSensitiveErr)
+			return
+		}
+
+		w.Header().Set("Authorization", httpcmn.MakeAuthorizationHeader(token))
+		c.SetLastHealthCheck(time.Now())
+		logs.Debug("HDS health check ok")
 	}
 
-	w.Header().Set("Authorization", httpcmn.MakeAuthorizationHeader(token))
 	httpcmn.OK(w)
-
-	c.SetLastHealthCheck(time.Now())
-	logs.Debug("health check ok")
 }
 
 // GetServers returns a list of the closest servers.

--- a/hdsclient/client.go
+++ b/hdsclient/client.go
@@ -270,7 +270,7 @@ func (c *Client) HandleServerRegistration(w http.ResponseWriter, r *http.Request
 //
 // This handler is meant to be used by a Hagall server under the /health path.
 func (c *Client) HandleHealthCheck(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodGet {
+	if r.Method != http.MethodGet && r.Method != http.MethodHead {
 		httpcmn.MethodNotAllowed(w)
 		return
 	}


### PR DESCRIPTION
https://auki.atlassian.net/browse/PI-552

Only update the "last health check" time and add response header with a signed server identity if requests seem to come from HDS.

This allows for UptimeRobot and other monitoring services to call the health check endpoint without messing with the "last health check" time as that's used to detect if re-registration is needed after failed smoke tests or health checks.

Thanks to **sk3ttch** for helping us with detailed information so we could find the issue.

Also allows HEAD calls to the health check endpoint as this was requested by the community.